### PR TITLE
Set derive feature for serde

### DIFF
--- a/tandem/Cargo.toml
+++ b/tandem/Cargo.toml
@@ -19,7 +19,7 @@ keywords = [
 rand = "0.8.3"
 rand_chacha = "0.3.1"
 blake3 = { version = "1.5.0", features = ["traits-preview"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 curve25519-dalek-ng = "4.1.1"
 


### PR DESCRIPTION
For me using tandem as a lib only works when setting the derive feature of serde. This is also set in `tandem_http_client`, I don't know why not in tandem. With that it works for me!